### PR TITLE
Added API Token to CI

### DIFF
--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -27,11 +27,6 @@ jobs:
           LOG_FILE: "log.log"
           GITHUB_TOKEN: ${{ secrets.CI_API_TOKEN }}
       run: |
-          if [ -z "$GITHUB_TOKEN" ]; then
-            echo "GITHUB_TOKEN is not set"
-          else
-            echo "GITHUB_TOKEN is set"
-          fi
           ./run test
           cat log.log
           


### PR DESCRIPTION
Now tests are actually run properly using an API token, and the logs are printed out under the build logs.